### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Personal CSS design project meant to learn about learning and using vanilla css.
 ## How to Run
 Just follow the link to repli and hit run to see the live version.
  
+ [![Run on Repl.it](https://repl.it/badge/github/rmvirut/fx300MS)](https://repl.it/github/rmvirut/fx300MS)
+
+
+Just in case the above markdown doesn't render, here's a direct link.
 [Run fx300MS on Repl.it](https://repl.it/@rmvirut/fx300MS) (doesn't require any download)
 
 ## The Real Thing


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@rmvirut/fx300MS).